### PR TITLE
Loop for moved out from constructor of class Logable

### DIFF
--- a/JavaScript/3-class.js
+++ b/JavaScript/3-class.js
@@ -1,35 +1,37 @@
 'use strict';
 
-const logable = fields => class Logable {
-  constructor(data) {
-    this.values = data;
-    for (const key in fields) {
-      Object.defineProperty(Logable.prototype, key, {
-        get() {
-          console.log('Reading key:', key);
-          return this.values[key];
-        },
-        set(value) {
-          console.log('Writing key:', key, value);
-          const def = fields[key];
-          const valid = (
-            typeof value === def.type &&
-            def.validate(value)
-          );
-          if (valid) this.values[key] = value;
-          else console.log('Validation failed:', key, value);
-        }
-      });
+const logable = fields => {
+  class Logable {
+    constructor(data) {
+      this.values = data;
+    }
+    toString() {
+      let result = this.constructor.name + '\t';
+      for (const key in fields) {
+        result += this.values[key] + '\t';
+      }
+      return result;
     }
   }
-
-  toString() {
-    let result = this.constructor.name + '\t';
-    for (const key in fields) {
-      result += this.values[key] + '\t';
-    }
-    return result;
+  for (const key in fields) {
+    Object.defineProperty(Logable.prototype, key, {
+      get() {
+        console.log('Reading key:', key);
+        return this.values[key];
+      },
+      set(value) {
+        console.log('Writing key:', key, value);
+        const def = fields[key];
+        const valid = (
+          typeof value === def.type &&
+          def.validate(value)
+        );
+        if (valid) this.values[key] = value;
+        else console.log('Validation failed:', key, value);
+      }
+    });
   }
+  return Logable;
 };
 
 // Usage


### PR DESCRIPTION
В текущем коде нет возможности создать новый инстанс класса Person.
- При добавлении такой строки: 
  const p2 = new Person({ name: 'Marcus Aurelius', born: 121 });

- Выдает ошибку:
      Object.defineProperty(Logable.prototype, key, {
             ^
TypeError: Cannot redefine property: name

Для устранения этого явления цикл for был вынесен за пределы constructor и при создании нового инстанса не происходит переопределение свойств Logable.prototype.  

В остальном поведение функции logable и класса Logable не изменилось.