### PR TITLE
Fix examples `3-class` and `7-pool`

### DIFF
--- a/JavaScript/3-class.js
+++ b/JavaScript/3-class.js
@@ -5,7 +5,7 @@ const logable = (fields) =>
     constructor(data) {
       this.values = data;
       for (const key in fields) {
-        Object.defineProperty(Logable.prototype, key, {
+        Object.defineProperty(this, key, {
           get() {
             console.log('Reading key:', key);
             return this.values[key];

--- a/JavaScript/7-pool.js
+++ b/JavaScript/7-pool.js
@@ -26,14 +26,14 @@ const a1 = arrayPool();
 const b1 = a1.map((x, i) => i).reduce((x, y) => x + y);
 console.log(b1);
 
-const a2 = arrays();
+const a2 = arrayPool();
 const b2 = a2.map((x, i) => i).reduce((x, y) => x + y);
 console.log(b2);
 
-arrays(a1);
-arrays(a2);
+arrayPool(a1);
+arrayPool(a2);
 
-const a3 = arrays();
+const a3 = arrayPool();
 const b3 = a3.map((x, i) => i).reduce((x, y) => x + y);
 console.log(b3);
 


### PR DESCRIPTION
The current implementation of `3-class` doesn't allow creating more than 1 instance and throws the following error in such case:
``` 
TypeError: Cannot redefine property: name
```

The reason is that `Object.defineProperty` defines properties directly for `Logable.prototype` instead of the instance being processed.


`7-pool` references to the name of the variable from the previous commit that has been changed. Therefore throws an error:
```
ReferenceError: arrays is not defined
```